### PR TITLE
Fix 404 not found links in README for the repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ![GitHub Workflow Status (with event)](https://github.com/GravityCloudAI/matter-ai/actions/workflows/main.yml/badge.svg?branch=main)
 ![Docker Pulls](https://img.shields.io/docker/pulls/gravitycloud/matter.svg?maxAge=604800)
-[![GitHub License](https://img.shields.io/github/license/GravityCloudAI/matter-ai)](https://github.com/GravityCloudAI/matter/blob/matter-ai/LICENSE)
+[![GitHub License](https://img.shields.io/github/license/GravityCloudAI/matter-ai)](https://github.com/GravityCloudAI/matter-ai/blob/matter-ai/LICENSE)
 ![Security Compliance](https://img.shields.io/badge/Compliance-SOC2_Type_II-818aff)
 ![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen?logo=github) 
 [![Tweet](https://img.shields.io/twitter/url?url=https%3A%2F%2Fmatterai.so%2F)](https://twitter.com/intent/tweet?url=&text=Check%20out%20%40matteraidev)
@@ -95,7 +95,7 @@ Matter is open-source AI Code Reviewer Agent. This enables developers to review 
 1. Generate a Github Personal Access Token(Classic) here: https://github.com/settings/tokens/new
 
 #### Steps
-1. Download the docker-compose.yaml file from here: [https://github.com/GravityCloudAI/matter/blob/main/docker-compose.yaml](https://github.com/GravityCloudAI/matter/blob/main/docker-compose.yaml)
+1. Download the docker-compose.yaml file from here: [https://github.com/GravityCloudAI/matter-ai/blob/main/docker-compose.yaml](https://github.com/GravityCloudAI/matter-ai/blob/main/docker-compose.yaml)
 2. Update the ENV for the backend service in the docker-compose.yaml file. You can get your Gravity API key here: https://app.matterai.so/settings
 3. Run `docker compose up -d`
 4. The app will start syncing with your Github Repositories and store the data.
@@ -106,7 +106,7 @@ Matter is open-source AI Code Reviewer Agent. This enables developers to review 
 
 #### Prerequisites
 1. Node.js
-2. Update .env file with the required values. You can get the template here: [https://github.com/GravityCloudAI/matter/blob/main/.env.example](https://github.com/GravityCloudAI/matter/blob/main/.env.example)
+2. Update .env file with the required values. You can get the template here: [https://github.com/GravityCloudAI/matter-ai/blob/main/.env.example](https://github.com/GravityCloudAI/matter-ai/blob/main/.env.example)
 
 #### Installation
 1. `npm install`


### PR DESCRIPTION
## Description

Fix 404 not found links in README for the repo name. Updated three broken GitHub repository links that were pointing to incorrect repository paths from `GravityCloudAI/matter` to the correct `GravityCloudAI/matter-ai`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing
  - Verified all updated links are accessible and point to correct repository paths
  - Confirmed LICENSE link now resolves correctly
  - Verified docker-compose.yaml and .env.example links work properly

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->
N/A - Documentation link fixes only

## Checklist
<!-- Put an 'x' in the boxes that apply -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
